### PR TITLE
fix(setup scripts): added \n to printf call, pip detection cascade, better error messages, and fix typos #6 #7

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -1,4 +1,4 @@
-&commat;echo off
+@echo off
 
 setlocal EnableExtensions EnableDelayedExpansion
 
@@ -27,18 +27,18 @@ where /q meson
 if errorlevel 1 (
   call :info "MESON BUILD SYSTEM IS NOT INSTALLED"
   call :info "ATTEMPTING TO INSTALL MESON"
-  call :info "CHECKING IF PYTHON'S PIP TOOL IS INSTALLED AS pip3"
-
-  where /q pip3
+  call :info "CHECKING FOR A WORKING PIP COMMAND"
+  call :find_pip
   if errorlevel 1 (
-    call :error "PYTHON'S PIP TOOL IS NOT INSTALLED AS pip3"
+    call :error "NO WORKING PIP COMMAND FOUND"
+    call :error "TRIED: pip, pip3, py -m pip, python -m pip, python3 -m pip"
     call :error "ABORTING ALL"
     exit /b 10
   )
 
-  call :ok "PYTHON'S PIP TOOL IS INSTALLED"
+  call :ok "FOUND PIP AS: !PIP_CMD!"
   call :info "INSTALLING MESON THROUGH PIP"
-  pip3 install --user meson
+  !PIP_CMD! install --user meson
   if errorlevel 1 (
     call :error "PIP FAILED TO INSTALL MESON...ABORTING"
     exit /b 11
@@ -46,8 +46,8 @@ if errorlevel 1 (
 
   where /q meson
   if errorlevel 1 (
-    call :error "MESON FAILED TO INSTALL (MESON STILL NOT ON PATH)...ABORTING"
-    call :warning "You may need to reopen the terminal or add your Python user scripts directory to PATH."
+    call :warning "MESON WAS INSTALLED BUT IS NOT ON PATH"
+    call :warning "ADD YOUR PYTHON USER SCRIPTS DIRECTORY TO PATH, REOPEN THE TERMINAL, AND RUN setup.bat AGAIN"
     exit /b 11
   ) else (
     call :ok "MESON IS INSTALLED SUCCESSFULLY"
@@ -139,3 +139,46 @@ exit /b 0
 :ok
 call :print "%GREEN%" "OK" "%~1"
 exit /b 0
+
+:find_pip
+where /q pip
+if not errorlevel 1 (
+  set "PIP_CMD=pip"
+  call :debug "FOUND PIP COMMAND: pip"
+  exit /b 0
+)
+where /q pip3
+if not errorlevel 1 (
+  set "PIP_CMD=pip3"
+  call :debug "FOUND PIP COMMAND: pip3"
+  exit /b 0
+)
+where /q py
+if not errorlevel 1 (
+  py -m pip --version >nul 2>&1
+  if not errorlevel 1 (
+    set "PIP_CMD=py -m pip"
+    call :debug "FOUND PIP COMMAND: py -m pip"
+    exit /b 0
+  )
+)
+where /q python
+if not errorlevel 1 (
+  python -m pip --version >nul 2>&1
+  if not errorlevel 1 (
+    set "PIP_CMD=python -m pip"
+    call :debug "FOUND PIP COMMAND: python -m pip"
+    exit /b 0
+  )
+)
+where /q python3
+if not errorlevel 1 (
+  python3 -m pip --version >nul 2>&1
+  if not errorlevel 1 (
+    set "PIP_CMD=python3 -m pip"
+    call :debug "FOUND PIP COMMAND: python3 -m pip"
+    exit /b 0
+  )
+)
+set "PIP_CMD="
+exit /b 1

--- a/setup.sh
+++ b/setup.sh
@@ -55,21 +55,34 @@ print_info "CHECKING IF THE MESON BUILD TOOL IS INSTALLED"
 if ! command -v meson >/dev/null 2>&1; then
   print_info "MESON BUILD SYSTEM IS NOT INSTALLED"
   print_info "ATTEMPTING TO INSTALL MESON"
-  print_info "CHECKING IF PYTHON'S PIP TOOL IS INSTALLED AS pip3"
-  if ! command -v pip3 >/dev/null 2>&1; then
-    print_error "PYTHON'S PIP TOOL IS NOT INSTALLED AS pip3"
+  print_info "CHECKING FOR A WORKING PIP COMMAND"
+  PIP_CMD=""
+  if command -v pip3 >/dev/null 2>&1; then
+    PIP_CMD="pip3"
+  elif command -v python3 >/dev/null 2>&1 && python3 -m pip --version >/dev/null 2>&1; then
+    PIP_CMD="python3 -m pip"
+  elif command -v pip >/dev/null 2>&1; then
+    PIP_CMD="pip"
+  elif command -v python >/dev/null 2>&1 && python -m pip --version >/dev/null 2>&1; then
+    PIP_CMD="python -m pip"
+  fi
+
+  if [ -z "$PIP_CMD" ]; then
+    print_error "NO WORKING PIP COMMAND FOUND"
+    print_error "TRIED: pip3, python3 -m pip, pip, python -m pip"
     print_error "ABORTING ALL"
     exit 10
   fi
 
-  print_good "PYTHON'S PIP TOOL IS INSTALLED"
+  print_good "FOUND PIP AS: $PIP_CMD"
   print_info "INSTALLING MESON THROUGH PIP"
-  pip3 install --user meson
+  $PIP_CMD install --user meson
 
   if command -v meson >/dev/null 2>&1; then
     print_good "MESON IS INSTALLED SUCCESSFULLY"
   else
-    print_error "MESON FAILED TO INSTALL...ABORTING"
+    print_warning "MESON WAS INSTALLED BUT IS NOT ON PATH"
+    print_warning "ADD YOUR PYTHON USER SCRIPTS DIRECTORY TO PATH, REOPEN THE TERMINAL, AND RUN setup.sh AGAIN"
     exit 11
   fi
 else

--- a/setup.sh
+++ b/setup.sh
@@ -73,7 +73,7 @@ if ! command -v meson >/dev/null 2>&1; then
     exit 11
   fi
 else
-  print_good "MASON IS INSTALLED ON THE SYSTEM"
+  print_good "MESON IS INSTALLED ON THE SYSTEM"
 fi
 
 print_debug "CALCULATING PATH TO SUBPROJECTS SUB-DIRECTORY..."

--- a/setup.sh
+++ b/setup.sh
@@ -28,7 +28,7 @@ print() {
   text=$1
   message_type=$3
 
-  printf "%s %s: $text %s" "$color" "$message_type" "$NO_COLOR"
+  printf "%s %s: $text %s\n" "$color" "$message_type" "$NO_COLOR"
 }
 
 print_error() {


### PR DESCRIPTION
## What
related issues: #6 #7 
added \n to printf call in setup.sh
fixed a typo in setup.sh
added better pip detection support in setup scripts and improved an error message in both scripts.

- [x] changes to setup.sh
- [x] changes to setup.bat
## Why

improves formatting
expands support for detecting dependencies on different linux distros. 
## Testing
setup.sh:
confirmed pip detection working
ran script on WSL Ubuntu, Archlinux
